### PR TITLE
API updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The API is currently backed by a [PostgreSQL](https://www.postgresql.org/) datab
 ### Data sources
 
 Most of our data comes from [Open Data SF](https://datasf.org/opendata/). See `db/seeds.rb` and
-`Dockerfile.db` for further details.
+`Dockerfile.db` for further details. The specific Sf 311 case data comes from https://data.sfgov.org/City-Infrastructure/311-Cases/vw6y-z8j6.
 
 ### Local DB
 

--- a/app/controllers/api/bikeway_networks_controller.rb
+++ b/app/controllers/api/bikeway_networks_controller.rb
@@ -12,4 +12,8 @@ class Api::BikewayNetworksController < ApplicationController
       end
     end
   end
+
+  def show
+    @bikeway_network = BikewayNetwork.find(params[:id])
+  end
 end

--- a/app/controllers/api/sf311_cases_controller.rb
+++ b/app/controllers/api/sf311_cases_controller.rb
@@ -1,18 +1,9 @@
 class Api::Sf311CasesController < ApplicationController
   def index
-    lane_blockages_query = Sf311Case.bike_lane_blockage
-
-    if params[:start_time]
-      lane_blockages_query =
-        lane_blockages_query.where('requested_datetime >= ?', params[:start_time])
-    end
-
-    if params[:end_time]
-      lane_blockages_query =
-        lane_blockages_query.where('requested_datetime <= ?', params[:end_time])
-    end
-
-    paginate json: lane_blockages_query
+    @lane_blockages = Sf311Case.includes(:sf311_case_metadatum)
+    @lane_blockages = @lane_blockages.where('requested_datetime >= ?', params[:start_time]) if params[:start_time]
+    @lane_blockages = @lane_blockages.where('requested_datetime <= ?', params[:end_time]) if params[:end_time]
+    @lane_blockages = @lane_blockages.paginate(page: (params[:page] || 1), per_page: (params[:per_page] || 30))
   end
 
   def create

--- a/app/models/sf311_case.rb
+++ b/app/models/sf311_case.rb
@@ -49,14 +49,11 @@ class Sf311Case < ApplicationRecord
     blocked_bike_lane: 'Blocking_Bicycle_Lane'
   }
 
-  scope :bike_lane_blockage, -> { where(service_subtype: SERVICE_SUBTYPES[:blocked_bike_lane]) }
-
   def add_metadata
     Sf311CaseMetadatum.update_metadata(self)
   end
 
   class << self
-
     def ingest_csv_case_data!(case_data_csv)
       # TODO: Figure out a more efficient way to import case records. Currently,
       # each record takes 2 SQL statements to create (1 for the record itself,
@@ -65,7 +62,5 @@ class Sf311Case < ApplicationRecord
         Sf311Case.create!(row.to_h)
       end
     end
-
   end
-
 end

--- a/app/views/api/bikeway_networks/_bikeway_network.json.jbuilder
+++ b/app/views/api/bikeway_networks/_bikeway_network.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! bikeway_network, :id, :install_mo, :install_yr, :symbology, :streetname

--- a/app/views/api/bikeway_networks/show.json.jbuilder
+++ b/app/views/api/bikeway_networks/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "api/bikeway_networks/bikeway_network", bikeway_network: @bikeway_network

--- a/app/views/api/sf311_cases/index.json.jbuilder
+++ b/app/views/api/sf311_cases/index.json.jbuilder
@@ -1,0 +1,21 @@
+json.meta do
+  json.current_page @lane_blockages.current_page
+  json.next_page @lane_blockages.next_page
+  json.prev_page @lane_blockages.previous_page
+  json.total_pages @lane_blockages.total_pages
+  json.total_count @lane_blockages.total_entries
+  json.items_per_page @lane_blockages.per_page
+end
+json.data @lane_blockages do |lane_blockage|
+  json.extract! lane_blockage, :id, :service_request_id, :requested_datetime, :closed_date, :updated_datetime, :status_description,
+  :status_notes, :agency_responsible, :service_name, :service_subtype, :service_details, :address, :supervisor_district,
+  :neighborhoods_sffind_boundaries, :police_district, :lat, :long, :source, :media_url
+  
+  if lane_blockage.sf311_case_metadatum.present?
+    json.meta_data do
+      json.bikeway_network_id lane_blockage.sf311_case_metadatum.bikeway_network_id
+    end
+  else
+    json.meta_data nil
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,6 @@ Rails.application.routes.draw do
     get '/bikeway_networks', to: 'bikeway_networks#nearest_network'
     resources :sf311_case_metadata, only: [:index]
     resources :sf311_cases, only: [:index, :create]
-  end
+    resources :bikeway_networks, only: [:show]
+  end  
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,18 @@
+require 'sidekiq/web'
+unless Rails.env.development?
+  Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+    ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV['SIDEKIQ_USERNAME'])) &
+      ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV['SIDEKIQ_PASSWORD']))
+  end
+end
+
 Rails.application.routes.draw do
+  mount Sidekiq::Web, at: '/sidekiq'
+
+  root :to => proc { [200,
+    {"Content-Type" => "text/html"},
+    ['Welcome to Lane Breach\'s api. Learn more at https://github.com/lanebreach/lanebreach-api.']] }
+
   post "/graphql", to: "graphql#execute"
 
   namespace :api, defaults: { format: 'json' } do

--- a/docs.md
+++ b/docs.md
@@ -26,6 +26,18 @@ curl -XGET https://lane-breach.herokuapp.com/api/bikeway_networks?lat=-122.45872
 null
 ```
 
+#### GET /api/bikeway_networks/ID
+
+**request:**
+```
+curl -XGET https://lane-breach.herokuapp.com/api/bikeway_networks/4150
+```
+
+**response:**
+```
+{"id":4150,"install_mo":null,"install_yr":"2003.0","symbology":"BIKE LANE","streetname":"14TH ST"}
+```
+
 ### SF 311 Cases
 
 #### GET /api/sf311_cases
@@ -40,38 +52,43 @@ The default page size is 30 items.
 
 **response:**
 ```
-[
-  {
-    "id": 1,
-    "service_request_id": 9145772,
-    "requested_datetime": "2018-06-16T15:14:02.000Z",
-    "closed_date": "2018-06-16T15:14:09.000Z",
-    "updated_datetime": "2018-06-16T15:14:09.000Z",
-    "status_description": "Closed",
-    "status_notes": "The report has been logged and will help the City collect data on double parking and bike lane violations to determine target areas and future enforcement efforts. Thank you.",
-    "agency_responsible": "Parking Enforcement Review Queue",
-    "service_name": "Parking Enforcement",
-    "service_subtype": "Blocking_Bicycle_Lane",
-    "service_details": "Parking Enforcement",
-    "address": "2927 FOLSOM ST, SAN FRANCISCO, CA, 94110",
-    "supervisor_district": 9,
-    "neighborhoods_sffind_boundaries": "Mission",
-    "police_district": "MISSION",
-    "lat": 37.75041,
-    "long": -122.4138,
-    "point": "POINT (-122.41369887 37.75039981)",
-    "point_city": null,
-    "source": "Mobile/Open311",
-    "point_state": null,
-    "point_address": null,
-    "point_zip": null,
-    "media_url_description": null,
-    "media_url": null,
-    "created_at": "2018-11-24T19:54:31.565Z",
-    "updated_at": "2018-11-24T19:54:31.565Z"
+{
+  "meta": {
+    "current_page": 1,
+    "next_page": 2,
+    "prev_page": null,
+    "total_pages": 12,
+    "total_count": 354,
+    "items_per_page": 30
   },
-  ...
-]
+  "data": [
+    {
+      "id": 375,
+      "service_request_id": 9875356,
+      "requested_datetime": "2018-12-01T00:51:00.000Z",
+      "closed_date": "2018-12-01T00:53:38.000Z",
+      "updated_datetime": "2018-12-01T00:53:38.000Z",
+      "status_description": "Closed",
+      "status_notes": "The report has been logged and will help the City collect data on double parking and bike lane violations to determine target areas and future enforcement efforts. Thank you.",
+      "agency_responsible": "Parking Enforcement Dispatch Queue",
+      "service_name": "Parking Enforcement",
+      "service_subtype": "Blocking_Bicycle_Lane",
+      "service_details": "White - Toyota Camry - NA",
+      "address": "1842 LAKE ST, SAN FRANCISCO, CA, 94121",
+      "supervisor_district": 2,
+      "neighborhoods_sffind_boundaries": "Lake Street",
+      "police_district": "RICHMOND",
+      "lat": 37.78612137,
+      "long": -122.47961426,
+      "source": "Phone",
+      "media_url": null,
+      "meta_data": {
+        "bikeway_network_id": 4277
+      }
+    },
+    ...
+  ]
+}
 ```
 
 #### POST /api/sf311_cases


### PR DESCRIPTION
Nothing too exciting:

* I mostly added some page meta data to our sf311 case call so that it now looks like the below
* Added `https://lane-breach.herokuapp.com/sidekiq` to show the sidekiq web console. Username and password are env properties stored in Heroku.
* Added default messaging `https://lane-breach.herokuapp.com` to point to our github.
* Added `GET /api/bikeway_networks/ID` call
* Some minor refactoring

```
{
  "meta": {
    "current_page": 1,
    "next_page": 2,
    "prev_page": null,
    "total_pages": 12,
    "total_count": 354,
    "items_per_page": 30
  },
  "data": [
    {
      "id": 375,
      "service_request_id": 9875356,
      "requested_datetime": "2018-12-01T00:51:00.000Z",
      "closed_date": "2018-12-01T00:53:38.000Z",
      "updated_datetime": "2018-12-01T00:53:38.000Z",
      "status_description": "Closed",
      "status_notes": "The report has been logged and will help the City collect data on double parking and bike lane violations to determine target areas and future enforcement efforts. Thank you.",
      "agency_responsible": "Parking Enforcement Dispatch Queue",
      "service_name": "Parking Enforcement",
      "service_subtype": "Blocking_Bicycle_Lane",
      "service_details": "White - Toyota Camry - NA",
      "address": "1842 LAKE ST, SAN FRANCISCO, CA, 94121",
      "supervisor_district": 2,
      "neighborhoods_sffind_boundaries": "Lake Street",
      "police_district": "RICHMOND",
      "lat": 37.78612137,
      "long": -122.47961426,
      "source": "Phone",
      "media_url": null,
      "meta_data": {
        "bikeway_network_id": 4277
      }
    },
    ...
  ]
}
```