### PR TITLE
Add Procfile to run migrations automatically on deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,4 @@
+web: bundle exec puma -C config/puma.rb
+worker bundle exec sidekiq
+
+release: rails db:migrate

--- a/README.md
+++ b/README.md
@@ -38,11 +38,9 @@ Check your Heroku account to retrieve the password or talk to a maintainer.
 
 ## Deployment
 
-The app lives on [Heroku](https://www.heroku.com/) at https://lane-breach.herokuapp.com/ which you must be logged into to deploy. Make sure to add the heroku remote using `heroku git:remote -a lane-breach`.
+The app lives on [Heroku](https://www.heroku.com/) at https://lane-breach.herokuapp.com/. Any pushes to the `heroku` branch will get automatically deployed, including migrations.
 
-You can push a new version of the app by running `git push -f heroku master`. See the [Git deployment documentation](https://devcenter.heroku.com/articles/git) for further details.
-
-You can run database migrations by running `heroku run rails db:migrate`. You only need to run migrations if you've added a new [database migration](https://edgeguides.rubyonrails.org/active_record_migrations.html).
+To push what's on master onto the heroku branch, you can run `git push origin master:heroku`.
 
 ## Contributing
 


### PR DESCRIPTION
A couple things:
* I created a `heroku` branch and this is now linked to our heroku app. Any code push to this branch is now automatically deployed. I usually do this by updating master (or say after we merge a PR by running ` git push origin master:heroku`). This should eliminate the need to add new people to our heroku app and just make it smoother generally.
* On the same token, I made it so it it now runs migrations on deployments automatically.