### PR TITLE
SF MTA ridership count ingestion and endpoints

### DIFF
--- a/app/controllers/api/sf_mta_ridership_counts_controller.rb
+++ b/app/controllers/api/sf_mta_ridership_counts_controller.rb
@@ -1,0 +1,23 @@
+class Api::SfMtaRidershipCountsController < ApplicationController
+  def index
+    @ridership_counts = SfMtaRidershipCount
+
+    order_by = params[:order_by]
+
+    if order_by
+      sort_order = params[:sort_order] || 'DESC'
+      return render json: { error: 'Supported sort_order values are ASC and DESC' }, status: :bad_request unless sort_order&.upcase.in?(%w[ASC DESC])
+
+      @ridership_counts = @ridership_counts.order("#{order_by} #{sort_order}")
+    end
+
+    @ridership_counts = @ridership_counts.where(counter_location: params[:counter_location]) if params[:counter_location]
+    @ridership_counts = @ridership_counts.where(days: params[:days].upcase) if params[:days]
+    @ridership_counts = @ridership_counts.where(hour_of_collection_time: params[:hour_of_collection_time]) if params[:hour_of_collection_time]
+    @ridership_counts = @ridership_counts.where(month_of_collection_time: params[:month_of_collection_time].capitalize) if params[:month_of_collection_time]
+    @ridership_counts = @ridership_counts.where(year_of_collection_time: params[:year_of_collection_time]) if params[:year_of_collection_time]
+    @ridership_counts = @ridership_counts.where(total_bike_count: params[:total_bike_count]) if params[:total_bike_count]
+
+    @ridership_counts = @ridership_counts.paginate(page: (params[:page] || 1), per_page: (params[:per_page] || 30))
+  end
+end

--- a/app/graphql/connections/sf_mta_ridership_counts_connection.rb
+++ b/app/graphql/connections/sf_mta_ridership_counts_connection.rb
@@ -1,0 +1,11 @@
+Connections::SfMtaRidershipCountsConnection = Types::SfMtaRidershipCountType.define_connection do
+  name 'SfMtaRidershipCountsConnection'
+
+  field :totalCount do
+    type types.Int
+
+    resolve -> (obj, _args, _ctx) {
+      obj.nodes.count
+    }
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -3,7 +3,7 @@ Types::QueryType = GraphQL::ObjectType.define do
 
   # SF 311 Case Queries:
   connection :sf311_cases_connection, Connections::Sf311CasesConnection do
-    description 'Returns the SF 311 Cases that took place within the specified date range'
+    description 'Returns the SF 311 Cases that satisfy the specified conditions'
 
     argument :start_time, Types::DateTimeType
     argument :end_time, Types::DateTimeType
@@ -35,5 +35,33 @@ Types::QueryType = GraphQL::ObjectType.define do
     argument :max_distance, types.Float
 
     resolve -> (obj, args, ctx) { BikewayNetwork.nearest(args[:lat], args[:long], args[:max_distance]) }
+  end
+
+  # SF MTA Ridership Counts
+  connection :sf_mta_ridership_counts_connection, Connections::SfMtaRidershipCountsConnection do
+    description 'Returns the SF MTA Ridership Counts that satisfy the specified conditions'
+
+    argument :counter_location, types.String
+    argument :days, types.Int
+    argument :hour_of_collection, types.Int
+    argument :month_of_collection, types.String
+    argument :year_of_collection, types.Int
+    argument :total_bike_count, types.Int
+
+    argument :order_by, types.String, 'Column to order the results by', as: :order_by, default_value: :total_bike_count
+    argument :sort_order, types.String, 'Ascending or descending ordering of sorted results', as: :sort_order, default_value: :desc
+
+    resolve -> (obj, args, ctx) {
+      ridership_count_query = SfMtaRidershipCount.order("#{args[:order_by]} #{args[:sort_order]}")
+
+      ridership_count_query = ridership_count_query.where(counter_location: args[:counter_location]) if args[:counter_location]
+      ridership_count_query = ridership_count_query.where(days: args[:days].upcase) if args[:days]
+      ridership_count_query = ridership_count_query.where(hour_of_collection_time: args[:hour_of_collection_time]) if args[:hour_of_collection_time]
+      ridership_count_query = ridership_count_query.where(month_of_collection_time: args[:month_of_collection_time].capitalize) if args[:month_of_collection_time]
+      ridership_count_query = ridership_count_query.where(year_of_collection_time: args[:year_of_collection_time]) if args[:year_of_collection_time]
+      ridership_count_query = ridership_count_query.where(total_bike_count: args[:total_bike_count]) if args[:total_bike_count]
+
+      ridership_count_query
+    }
   end
 end

--- a/app/graphql/types/sf_mta_ridership_count_type.rb
+++ b/app/graphql/types/sf_mta_ridership_count_type.rb
@@ -1,0 +1,10 @@
+Types::SfMtaRidershipCountType = GraphQL::ObjectType.define do
+  name SfMtaRidershipCount.to_s
+
+  field :counter_location, types.String
+  field :days, types.String
+  field :hour_of_collection_time, types.String
+  field :month_of_collection_time, types.String
+  field :total_bike_count, types.Int
+  field :year_of_collection_time, types.Int
+end

--- a/app/models/sf_mta_ridership_count.rb
+++ b/app/models/sf_mta_ridership_count.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: sf_mta_ridership_counts
+#
+#  id                       :bigint(8)        not null, primary key
+#  counter_location         :string
+#  days                     :string
+#  hour_of_collection_time  :integer
+#  month_of_collection_time :string
+#  total_bike_count         :integer
+#  year_of_collection_time  :integer
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+
+class SfMtaRidershipCount < ApplicationRecord
+
+end

--- a/app/views/api/sf_mta_ridership_counts/index.json.jbuilder
+++ b/app/views/api/sf_mta_ridership_counts/index.json.jbuilder
@@ -1,0 +1,14 @@
+json.meta do
+  json.current_page @ridership_counts.current_page
+  json.next_page @ridership_counts.next_page
+  json.prev_page @ridership_counts.previous_page
+  json.total_pages @ridership_counts.total_pages
+  json.total_count @ridership_counts.total_entries
+  json.items_per_page @ridership_counts.per_page
+end
+
+json.data @ridership_counts do |ridership_count|
+  json.extract! ridership_count, :counter_location, :days,
+    :hour_of_collection_time, :month_of_collection_time,
+    :year_of_collection_time, :total_bike_count
+end

--- a/app/workers/ingest_sf_mta_hourly_ridership_counts_worker.rb
+++ b/app/workers/ingest_sf_mta_hourly_ridership_counts_worker.rb
@@ -1,0 +1,62 @@
+# Currently, the SF MTA hourly counts report only includes data through 2017 (see
+# https://www.sfmta.com/reports/hourly-bike-counts-dashboard for details). This worker
+# simply ingests the most recent counts file and should be modified to periodically
+# ingest new records once more up-to-date information is available.
+require 'csv'
+
+class IngestSfMtaHourlyRidershipCountsWorker
+  include Sidekiq::Worker
+
+  BULK_IMPORT_RECORD_COUNT = 1000
+  DOWNLOAD_TIMEOUT_IN_MINS = 5.minutes
+
+  RIDERSHIP_COUNTS_FILE_URL = 'https://stats.sfmta.com/t/public/views/AutomatedBicycleCounters/HOURLYTABLE.csv'
+
+  def perform
+    hourly_counts_file = download_hourly_counts_file
+
+    storage_time = Benchmark.realtime do
+      CSV.foreach(hourly_counts_file.path, headers: true, header_converters: :symbol).
+          each_slice(BULK_IMPORT_RECORD_COUNT) do |ridership_table_fragment|
+        ridership_counts = ridership_table_fragment.map { |row| row.to_h }
+        SfMtaRidershipCount.import!(ridership_counts)
+      end
+    end
+
+    Rails.logger.info("Stored the contents of the hourly counts file in #{storage_time} seconds")
+  ensure
+    hourly_counts_file&.delete
+  end
+
+  def download_hourly_counts_file
+    uri = URI(RIDERSHIP_COUNTS_FILE_URL)
+
+    http_client = Net::HTTP.new(uri.host, uri.port)
+
+    # TODO: Usually not a good idea to skip SSL certification; find a way around this
+    http_client.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+    http_client.use_ssl = true
+    http_client.read_timeout = DOWNLOAD_TIMEOUT_IN_MINS
+
+    # This file is upwards of 10 MB and takes over a minute to download; store it on disk
+    # to reduce memory consumption and lessen the chances of a timeout:
+    hourly_counts_file = Tempfile.new('hourly_counts_table.csv')
+
+    request = Net::HTTP::Get.new(uri.request_uri)
+
+    file_download_time = Benchmark.realtime do
+      http_client.request(request) do |response|
+        response.read_body do |chunk|
+          hourly_counts_file.write(chunk)
+        end
+      end
+    end
+
+    hourly_counts_file.flush
+
+    Rails.logger.info("Downloaded the hourly counts file in #{file_download_time} seconds")
+
+    hourly_counts_file
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 require 'sidekiq/web'
+
 unless Rails.env.development?
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|
     ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV['SIDEKIQ_USERNAME'])) &
@@ -9,16 +10,22 @@ end
 Rails.application.routes.draw do
   mount Sidekiq::Web, at: '/sidekiq'
 
-  root :to => proc { [200,
-    {"Content-Type" => "text/html"},
-    ['Welcome to Lane Breach\'s api. Learn more at https://github.com/lanebreach/lanebreach-api.']] }
+  root :to => proc {
+    [
+      200,
+      { "Content-Type" => "text/html" },
+      ['Welcome to Lane Breach\'s api. Learn more at https://github.com/lanebreach/lanebreach-api.']
+    ]
+  }
 
   post "/graphql", to: "graphql#execute"
 
   namespace :api, defaults: { format: 'json' } do
     get '/bikeway_networks', to: 'bikeway_networks#nearest_network'
+
     resources :sf311_case_metadata, only: [:index]
     resources :sf311_cases, only: [:index, :create]
-    resources :bikeway_networks, only: [:show]
-  end  
+    resources :bikeway_networks, only: [:index, :show]
+    resources :sf_mta_ridership_counts, only: [:index]
+  end
 end

--- a/db/migrate/20190411041012_create_sf_mta_ridership_counts.rb
+++ b/db/migrate/20190411041012_create_sf_mta_ridership_counts.rb
@@ -1,0 +1,14 @@
+class CreateSfMtaRidershipCounts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sf_mta_ridership_counts do |t|
+      t.string :counter_location
+      t.string :days
+      t.integer :hour_of_collection_time
+      t.string :month_of_collection_time
+      t.integer :year_of_collection_time
+      t.integer :total_bike_count
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_16_204223) do
+ActiveRecord::Schema.define(version: 2019_04_11_041012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -97,6 +97,17 @@ ActiveRecord::Schema.define(version: 2019_03_16_204223) do
     t.string "description"
     t.index ["requested_datetime"], name: "index_sf311_cases_on_requested_datetime"
     t.index ["service_request_id"], name: "index_sf311_cases_on_service_request_id", unique: true
+  end
+
+  create_table "sf_mta_ridership_counts", force: :cascade do |t|
+    t.string "counter_location"
+    t.string "days"
+    t.integer "hour_of_collection_time"
+    t.string "month_of_collection_time"
+    t.integer "year_of_collection_time"
+    t.integer "total_bike_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_foreign_key "sf311_case_metadata", "bikeway_networks"

--- a/docs.md
+++ b/docs.md
@@ -199,6 +199,52 @@ curl -XPOST https://lane-breach.herokuapp.com/api/sf311_cases -H "Content-Type: 
 TBD
 ```
 
+### SF MTA Ridership Counts
+
+#### GET /api/sf_mta_ridership_counts
+
+**request:**
+```
+curl -XGET https://lane-breach.herokuapp.com/api/sf_mta_ridership_counts?year_of_collection_time=2016&day=weekday&order_by=total_bike_count
+```
+
+Supported query string parameters include `year_of_collection_time`, `month_of_collection_time`, `hour_of_collection_time`, `total_bike_count`, `counter_location` and `days`. See the example API response for the expected value types for these parameters.
+
+When an `order_by` parameter is specified, a `sort_order` (asc or desc) can also be included.
+
+**response:**
+```
+{
+  "meta": {
+    "current_page": 1,
+    "next_page": 2,
+    "prev_page": null,
+    "total_pages": 1800,
+    "total_count": 54000,
+    "items_per_page": 30
+  },
+  "data": [
+    {
+      "counter_location": "17th St East of Hoff St",
+      "days": "WEEKDAY",
+      "hour_of_collection_time": 10,
+      "month_of_collection_time": "February",
+      "year_of_collection_time": 2016,
+      "total_bike_count": 998
+    },
+    {
+      "counter_location": "Polk St South of Sutter St",
+      "days": "WEEKDAY",
+      "hour_of_collection_time": 20,
+      "month_of_collection_time": "February",
+      "year_of_collection_time": 2016,
+      "total_bike_count": 998
+    },
+    ...
+  ]
+}
+```
+
 ## GraphQL API Endpoints
 
 If you haven't used GraphQL before, be sure to skim through [the documentation](https://graphql.org/) so you can hit the ground running.
@@ -234,6 +280,8 @@ The simplest way to run and test GraphQL queries is to use the [GraphiQL interfa
   }
 }
 ```
+
+### SF 311 Cases
 
 #### Fetch the first 5 cases that took place between April and October 2018
 
@@ -327,6 +375,65 @@ The simplest way to run and test GraphQL queries is to use the [GraphiQL interfa
             "sf311_case_metadatum": {
               "bikeway_network_id": 1563
             }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### SF MTA Ridership Counts
+
+#### Fetch the location, bike count year and month of the top 3 ridership count records
+
+**request**:
+```
+{
+  sf_mta_ridership_counts_connection(order_by: total_bike_count, first: 3) {
+    totalCount
+    
+    edges {
+      node {
+        total_bike_count
+        counter_location
+        year_of_collection_time
+        month_of_collection_time        
+      }
+    }	
+  }
+}
+```
+
+**response**:
+```
+{
+  "data": {
+    "sf_mta_ridership_counts_connection": {
+      "totalCount": 108816,
+      "edges": [
+        {
+          "node": {
+            "total_bike_count": 998,
+            "counter_location": "17th St East of Hoff St",
+            "year_of_collection_time": 2016,
+            "month_of_collection_time": "February"
+          }
+        },
+        {
+          "node": {
+            "total_bike_count": 998,
+            "counter_location": "JFK West of Conservatory Dr. West",
+            "year_of_collection_time": 2017,
+            "month_of_collection_time": "June"
+          }
+        },
+        {
+          "node": {
+            "total_bike_count": 998,
+            "counter_location": "Marina Bike Path East of Baker St.",
+            "year_of_collection_time": 2017,
+            "month_of_collection_time": "October"
           }
         }
       ]


### PR DESCRIPTION
Addresses #13 

A worker for ingesting SF MTA ridership count data along with endpoints (both REST and GraphQL) for accessing that data have been added. See [the documentation](https://github.com/lanebreach/lanebreach-api/blob/feature/ridership-counts/docs.md#sf-mta-ridership-counts) for example requests. 

Support for basic parameterization has been added (e.g., retrieving ridership count records from April 2016), but more advanced parameters may be preferred. Let me know if API consumers prefer more / different query options.

**Note**: The ingestion worker is not built to be run periodically. Once we get a feel for how frequently the data will be updated and how much data will come with each update I'll update the ingestion worker logic accordingly.