### PR TITLE
Case ingestion job fix and monitoring improvements

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 require 'sidekiq/web'
+require 'sidekiq/cron/web'
 
 unless Rails.env.development?
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,4 +1,3 @@
 ingest_latest_blocked_lane_cases:
   cron: '0 5 * * *' # Daily at 5 AM
   class: IngestLatestBlockedLaneCasesWorker
-  queue: case_management

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,3 +1,3 @@
 ingest_latest_blocked_lane_cases:
-  cron: '0 5 * * *' # Daily at 5 AM
+  cron: '0 12 * * *' # Daily at 12 UTC
   class: IngestLatestBlockedLaneCasesWorker


### PR DESCRIPTION
The case ingestion job hasn't been running automatically because Sidekiq is currently configured to poll only the `default` queue, not the `case_management` queue. For the time being, I think it makes the most sense to use the `default` Sidekiq queue and move to multiple queues once job processing latency becomes an issue. More context here: https://stackoverflow.com/a/16836794/172620.

Aside from removing the custom queue declaration for `IngestLatestBlockedLaneCasesWorker`, I've also added [the CRON tab view](https://github.com/ondrejbartas/sidekiq-cron#web-ui-for-cron-jobs) to [the Sidekiq web UI](http://lane-breach.herokuapp.com/sidekiq/) so we have more visibility into which jobs are scheduled to run.