### PR TITLE
Add config flag to turn on compression

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,8 @@ module LanebreachApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    # Compress everything that we send
+    config.middleware.use Rack::Deflater
   end
 end


### PR DESCRIPTION
I'm not sure if this actually does what I want it to, since I didn't really know how to test this change locally. Basically the idea is that for the requests that support gzip or similar, we should actually zip the data that we send. This gives a reduction of about 93% (!) which speeds up the fetching of, e.g., a year's worth of data considerably.