### PR TITLE
Feature: only paginate if requested

### DIFF
--- a/app/controllers/api/sf311_cases_controller.rb
+++ b/app/controllers/api/sf311_cases_controller.rb
@@ -15,7 +15,7 @@ class Api::Sf311CasesController < ApplicationController
         @lane_blockages.where('requested_datetime <= ?', params[:end_time])
     end
 
-    if params[:page] || params[:per_page]
+    unless params.has_key?(:skip_pagination)
       @lane_blockages =
         @lane_blockages.paginate(
           page: (params[:page] || 1),

--- a/app/controllers/api/sf311_cases_controller.rb
+++ b/app/controllers/api/sf311_cases_controller.rb
@@ -12,11 +12,13 @@ class Api::Sf311CasesController < ApplicationController
         @lane_blockages.where('requested_datetime <= ?', params[:end_time])
     end
 
-    @lane_blockages =
-      @lane_blockages.paginate(
-        page: (params[:page] || 1),
-        per_page: (params[:per_page] || 30)
-      )
+    if params[:page] || params[:per_page]
+      @lane_blockages =
+        @lane_blockages.paginate(
+          page: (params[:page] || 1),
+          per_page: (params[:per_page] || 30)
+        )
+    end
   end
 
   def create

--- a/app/controllers/api/sf311_cases_controller.rb
+++ b/app/controllers/api/sf311_cases_controller.rb
@@ -1,9 +1,22 @@
 class Api::Sf311CasesController < ApplicationController
   def index
     @lane_blockages = Sf311Case.includes(:sf311_case_metadatum)
-    @lane_blockages = @lane_blockages.where('requested_datetime >= ?', params[:start_time]) if params[:start_time]
-    @lane_blockages = @lane_blockages.where('requested_datetime <= ?', params[:end_time]) if params[:end_time]
-    @lane_blockages = @lane_blockages.paginate(page: (params[:page] || 1), per_page: (params[:per_page] || 30))
+
+    if params[:start_time]
+      @lane_blockages =
+        @lane_blockages.where('requested_datetime >= ?', params[:start_time])
+    end
+
+    if params[:end_time]
+      @lane_blockages =
+        @lane_blockages.where('requested_datetime <= ?', params[:end_time])
+    end
+
+    @lane_blockages =
+      @lane_blockages.paginate(
+        page: (params[:page] || 1),
+        per_page: (params[:per_page] || 30)
+      )
   end
 
   def create
@@ -16,7 +29,8 @@ class Api::Sf311CasesController < ApplicationController
 
       render :show
     else
-      render json: { error: 'Error creating new 311 case' }, status: :unprocessable_entity
+      render json: { error: 'Error creating new 311 case' },
+             status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/sf311_cases_controller.rb
+++ b/app/controllers/api/sf311_cases_controller.rb
@@ -1,6 +1,9 @@
 class Api::Sf311CasesController < ApplicationController
   def index
-    @lane_blockages = Sf311Case.includes(:sf311_case_metadatum)
+    @lane_blockages =
+      Sf311Case
+        .left_outer_joins(:sf311_case_metadatum)
+        .select('sf311_cases.*,sf311_case_metadata.*')
 
     if params[:start_time]
       @lane_blockages =

--- a/app/models/bikeway_network.rb
+++ b/app/models/bikeway_network.rb
@@ -48,9 +48,10 @@ class BikewayNetwork < ApplicationRecord
 
   def self.nearest(lat, long, max_distance)
     max_distance ||= 50
-    BikewayNetwork.select("*, st_DistanceSphere(geom, ST_MakePoint(#{long}, #{lat})) as dist")
-                  .where("st_DistanceSphere(geom, ST_MakePoint(?, ?)) <= #{max_distance}", long, lat)
-                  .order('dist')
-                  .limit(1)
+    BikewayNetwork
+      .select("*, st_DistanceSphere(geom, ST_MakePoint(#{long}, #{lat})) as dist")
+      .where("st_DistanceSphere(geom, ST_MakePoint(?, ?)) <= #{max_distance}", long, lat)
+      .order('dist')
+      .limit(1)
   end
 end

--- a/app/models/sf311_case.rb
+++ b/app/models/sf311_case.rb
@@ -73,7 +73,8 @@ class Sf311Case < ApplicationRecord
         Sf311Case.create!(row.to_h)
         num_imported_cases += 1
 
-        # Sleep for a second to limit the number of requests made by the Sf311Case#add_description callback:
+        # Sleep for a second to limit the number of requests made by the
+        # Sf311Case#add_description callback:
         sleep(1)
       end
 

--- a/app/models/sf311_case_metadatum.rb
+++ b/app/models/sf311_case_metadatum.rb
@@ -28,9 +28,15 @@ class Sf311CaseMetadatum < ApplicationRecord
     return unless bikeway_network.present?
 
     if sf311_case.sf311_case_metadatum.present?
-      sf311_case.sf311_case_metadatum.update!(bikeway_network: bikeway_network, sf311_case: sf311_case)
+      sf311_case.sf311_case_metadatum.update!(
+        bikeway_network: bikeway_network,
+        sf311_case: sf311_case
+      )
     else
-      Sf311CaseMetadatum.create!(bikeway_network: bikeway_network, sf311_case: sf311_case)
+      Sf311CaseMetadatum.create!(
+        bikeway_network: bikeway_network,
+        sf311_case: sf311_case
+      )
     end
   end
 end

--- a/app/views/api/sf311_cases/index.json.jbuilder
+++ b/app/views/api/sf311_cases/index.json.jbuilder
@@ -17,9 +17,9 @@ json.data @lane_blockages do |lane_blockage|
                 :police_district, :lat, :long, :source, :media_url,
                 :description, :street
   
-  if lane_blockage.sf311_case_metadatum.present?
+  if lane_blockage.bikeway_network_id.present?
     json.meta_data do
-      json.bikeway_network_id lane_blockage.sf311_case_metadatum.bikeway_network_id
+      json.bikeway_network_id lane_blockage.bikeway_network_id
     end
   else
     json.meta_data nil

--- a/app/views/api/sf311_cases/index.json.jbuilder
+++ b/app/views/api/sf311_cases/index.json.jbuilder
@@ -7,9 +7,13 @@ json.meta do
   json.items_per_page @lane_blockages.per_page
 end
 json.data @lane_blockages do |lane_blockage|
-  json.extract! lane_blockage, :id, :service_request_id, :requested_datetime, :closed_date, :updated_datetime, :status_description,
-  :status_notes, :agency_responsible, :service_name, :service_subtype, :service_details, :address, :supervisor_district,
-  :neighborhoods_sffind_boundaries, :police_district, :lat, :long, :source, :media_url, :description, :street
+  json.extract! lane_blockage, :id, :service_request_id, :requested_datetime,
+                :closed_date, :updated_datetime, :status_description,
+                :status_notes, :agency_responsible, :service_name,
+                :service_subtype, :service_details, :address,
+                :supervisor_district, :neighborhoods_sffind_boundaries,
+                :police_district, :lat, :long, :source, :media_url,
+                :description, :street
   
   if lane_blockage.sf311_case_metadatum.present?
     json.meta_data do

--- a/app/views/api/sf311_cases/index.json.jbuilder
+++ b/app/views/api/sf311_cases/index.json.jbuilder
@@ -1,10 +1,12 @@
 json.meta do
-  json.current_page @lane_blockages.current_page
-  json.next_page @lane_blockages.next_page
-  json.prev_page @lane_blockages.previous_page
-  json.total_pages @lane_blockages.total_pages
-  json.total_count @lane_blockages.total_entries
-  json.items_per_page @lane_blockages.per_page
+  if @lane_blockages.respond_to? :total_pages
+    json.current_page @lane_blockages.current_page
+    json.next_page @lane_blockages.next_page
+    json.prev_page @lane_blockages.previous_page
+    json.total_pages @lane_blockages.total_pages
+    json.items_per_page @lane_blockages.per_page
+    json.total_count @lane_blockages.total_entries
+  end
 end
 json.data @lane_blockages do |lane_blockage|
   json.extract! lane_blockage, :id, :service_request_id, :requested_datetime,


### PR DESCRIPTION
This change does two things:

1. Removes the requirement that we paginate all of our requests
2. Changes the SQL generated for each request to be a single `left_outer_joins` rather than issuing two requests in order to avoid creating a huge 'IN' clause that causes our heroku instance to run out of memory (I'm assuming -- I don't know for sure, it just looked suspicious).